### PR TITLE
Fix up framework search paths in examples to find DeepBeliefSDK

### DIFF
--- a/examples/LearningExample/LearningExample.xcodeproj/project.pbxproj
+++ b/examples/LearningExample/LearningExample.xcodeproj/project.pbxproj
@@ -248,7 +248,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					/Users/petewarden/projects/DeepBeliefSDK,
+					"\"$(SRCROOT)/../../\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -302,7 +302,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					/Users/petewarden/projects/DeepBeliefSDK,
+					"\"$(SRCROOT)/../../\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/examples/SavedModelExample/SavedModelExample.xcodeproj/project.pbxproj
+++ b/examples/SavedModelExample/SavedModelExample.xcodeproj/project.pbxproj
@@ -248,7 +248,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					/Users/petewarden/projects/DeepBeliefSDK,
+					"\"$(SRCROOT)/../../\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -302,7 +302,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					/Users/petewarden/projects/DeepBeliefSDK,
+					"\"$(SRCROOT)/../../\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/examples/SimpleExample/SimpleExample.xcodeproj/project.pbxproj
+++ b/examples/SimpleExample/SimpleExample.xcodeproj/project.pbxproj
@@ -236,7 +236,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					/Users/petewarden/projects/DeepBeliefSDK,
+					"\"$(SRCROOT)/../../\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -290,7 +290,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					/Users/petewarden/projects/DeepBeliefSDK,
+					"\"$(SRCROOT)/../../\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;


### PR DESCRIPTION
This helps these example projects build out-of-the-box when checked out in paths other than `~petewarden/projects`.
