### PR TITLE
fix crash when use predictor in Android Library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+eigen/

--- a/source/.gitignore
+++ b/source/.gitignore
@@ -1,2 +1,5 @@
 *.o
+*.d
+*.so
+*.a
 data/example_networks/imagenet.ntwk

--- a/source/Android.mk
+++ b/source/Android.mk
@@ -1,4 +1,6 @@
-LIBSRCS:=$(shell find src/lib -name '*.cpp')
+LIBSRCS:=$(shell find src/lib -path src/lib/pi -prune -o -name '*.cpp' -print)
+${info ${LIBSRCS}}
+NDK_PATH := /Users/zhengzhiheng/android-ndk-r9d/
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 LOCAL_SRC_FILES := $(LIBSRCS)
@@ -14,8 +16,8 @@ LOCAL_C_INCLUDES += ./src/lib/include \
 ./src/lib \
 ./src/include \
 ../eigen \
-/Users/petewarden/android_ndk/sources/cxx-stl/gnu-libstdc++/4.6/include \
-/Users/petewarden/android_ndk/sources/cxx-stl/gnu-libstdc++/4.6/libs/armeabi/include
+$(NDK_PATH)/sources/cxx-stl/gnu-libstdc++/4.6/include \
+$(NDK_PATH)/sources/cxx-stl/gnu-libstdc++/4.6/libs/armeabi/include
 
 LOCAL_CFLAGS := -DUSE_EIGEN_GEMM -DUSE_NEON
 LOCAL_CFLAGS += -mfloat-abi=softfp -mfpu=neon -march=armv7

--- a/source/Android.mk
+++ b/source/Android.mk
@@ -19,7 +19,7 @@ LOCAL_C_INCLUDES += ./src/lib/include \
 $(NDK_PATH)/sources/cxx-stl/gnu-libstdc++/4.6/include \
 $(NDK_PATH)/sources/cxx-stl/gnu-libstdc++/4.6/libs/armeabi/include
 
-LOCAL_CFLAGS := -DUSE_EIGEN_GEMM -DUSE_NEON
+LOCAL_CFLAGS := -DUSE_EIGEN_GEMM 
 LOCAL_CFLAGS += -mfloat-abi=softfp -mfpu=neon -march=armv7
 
 LOCAL_CFLAGS += -fopenmp -O3

--- a/source/src/lib/svm/svm.cpp
+++ b/source/src/lib/svm/svm.cpp
@@ -2681,7 +2681,13 @@ int svm_save_model(const char *model_file_name, const svm_model *model)
 
 int svm_save_model_to_file_handle(FILE* fp, const svm_model* model) {
 
-	char *old_locale = strdup(setlocale(LC_ALL, NULL));
+	char *locale = setlocale(LC_ALL, NULL);
+	char *old_locale;
+	if (!locale)
+		old_locale = NULL;
+	else
+	 	old_locale = strdup(locale);
+	 	
 	setlocale(LC_ALL, "C");
 
 	const svm_parameter& param = model->param;
@@ -2797,7 +2803,12 @@ svm_model *svm_load_model(const char *model_file_name)
 	FILE *fp = fopen(model_file_name,"rb");
 	if(fp==NULL) return NULL;
 
-	char *old_locale = strdup(setlocale(LC_ALL, NULL));
+	char *locale = setlocale(LC_ALL, NULL);
+	char *old_locale;
+	if (!locale)
+		old_locale = NULL;
+	else
+	 	old_locale = strdup(locale);
 	setlocale(LC_ALL, "C");
 
 	// read parameters


### PR DESCRIPTION
I fixed this issue by modifying the source code of the jpcnn native library source code. It is because setlocale in android also returns NULL.

I also modify the Android.mk to exclude the pi directory when building the library. 
