### PR TITLE
iOS Demo: make framework search path relative to demo project

### DIFF
--- a/examples/SimpleiOS/SimpleExample.xcodeproj/project.pbxproj
+++ b/examples/SimpleiOS/SimpleExample.xcodeproj/project.pbxproj
@@ -234,10 +234,10 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
+					../../iOSLibrary,
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"\"$(SRCROOT)/../../\"",
-					/Users/petewarden/vagrant/DeepBeliefSDK/iOSLibrary,
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -289,10 +289,10 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
+					../../iOSLibrary,
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"\"$(SRCROOT)/../../\"",
-					/Users/petewarden/vagrant/DeepBeliefSDK/iOSLibrary,
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;


### PR DESCRIPTION
This solves this error when running the demo project: 
`SquareCamViewController.m:55:9: 'DeepBelief/DeepBelief.h' file not found`
