### PR TITLE
Update matrix_correlate.cpp

### DIFF
--- a/source/src/lib/math/matrix_correlate.cpp
+++ b/source/src/lib/math/matrix_correlate.cpp
@@ -72,7 +72,7 @@ Buffer* patches_into_rows(Buffer* input, int kernelWidth, int stride) {
         } else {
           size_t bytesToCopy;
           if (inputEndX > inputWidth) {
-            bytesToCopy = ((inputEndX - inputWidth) * inputChannels * sizeof(jpfloat_t));
+            bytesToCopy = ((kernelWidth - (inputEndX - inputWidth)) * inputChannels * sizeof(jpfloat_t));
           } else {
             bytesToCopy = bytesPerKernelRow;
           }


### PR DESCRIPTION
When expand the input matrix, the  patch_into_rows should zero left pixel in row direction. 
