### PR TITLE
Support for Raspberry Pi 2 and 3

### DIFF
--- a/source/src/lib/graph/buffer.cpp
+++ b/source/src/lib/graph/buffer.cpp
@@ -54,7 +54,7 @@ Buffer::Buffer(const Dimensions& dims) :
     fprintf(stderr, "Unable to allocate %d bytes of GPU memory\n", byteCount);
   }
   _gpuMemoryBase = mem_lock(_gpuMemoryHandle);
-  _data = (jpfloat_t*)(mapmem(_gpuMemoryBase + GPU_MEM_MAP, byteCount));
+  _data = (jpfloat_t*)(mapmem(BUS_TO_PHYS(_gpuMemoryBase + GPU_MEM_MAP), byteCount));
 #elif defined(USE_EIGEN_GEMM)
   _data = (jpfloat_t*)(Eigen::internal::aligned_malloc(byteCount));
 #else // TARGET_PI
@@ -119,7 +119,7 @@ Buffer::Buffer(const Dimensions& dims, jpfloat_t min, jpfloat_t max, int bitsPer
     fprintf(stderr, "Unable to allocate %d bytes of GPU memory\n", byteCount);
   }
   _gpuMemoryBase = mem_lock(_gpuMemoryHandle);
-  _quantizedData = (char*)(mapmem(_gpuMemoryBase + GPU_MEM_MAP, byteCount));
+  _quantizedData = (char*)(mapmem(BUS_TO_PHYS(_gpuMemoryBase + GPU_MEM_MAP), byteCount));
 #elif defined(USE_EIGEN_GEMM)
   _quantizedData = (void*)(Eigen::internal::aligned_malloc(byteCount));
 #else // TARGET_PI

--- a/source/src/lib/pi/mailbox.cpp
+++ b/source/src/lib/pi/mailbox.cpp
@@ -43,8 +43,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define MAJOR_NUM 100
 #define IOCTL_MBOX_PROPERTY _IOWR(MAJOR_NUM, 0, char *)
-#define DEVICE_DIRECTORY "/var/lib/jpcnn"
-#define DEVICE_PATH "/var/lib/jpcnn/char_dev"
+#define DEVICE_DIRECTORY "/dev"
+#define DEVICE_PATH DEVICE_DIRECTORY "/vcio"
 #define PAGE_SIZE (4*1024)
 
 int g_mailboxHandle = -1;

--- a/source/src/lib/pi/mailbox.h
+++ b/source/src/lib/pi/mailbox.h
@@ -47,4 +47,6 @@ unsigned execute_code(unsigned code, unsigned r0, unsigned r1, unsigned r2, unsi
 unsigned execute_qpu(unsigned num_qpus, unsigned control, unsigned noflush, unsigned timeout);
 unsigned qpu_enable(unsigned enable);
 
+#define BUS_TO_PHYS(x) ((((x)) & ~0xC0000000))
+
 #endif // INCLUDE_MAILBOX_H

--- a/source/src/lib/pi/qpu_gemm.cpp
+++ b/source/src/lib/pi/qpu_gemm.cpp
@@ -163,7 +163,7 @@ void qpu_cblas_sgemm_fixed(
     return;
   }
   uint32_t gpuMemoryBase = mem_lock(gpuMemoryHandle);
-  char* armMemoryBase = (char*)(mapmem(gpuMemoryBase + GPU_MEM_MAP, totalByteCount));
+  char* armMemoryBase = (char*)(mapmem(BUS_TO_PHYS(gpuMemoryBase + GPU_MEM_MAP), totalByteCount));
 
   const size_t messageOffset = 0;
   const size_t codeOffset = (messageOffset + messageByteCount);


### PR DESCRIPTION
Hi. This pull request is for supporting Raspberry Pi 2 and 3. Here are the changes:
- The Mailbox interface is now on `/dev/vcio`.
- GPU-side memory address must be masked before mapping on `/dev/mem` on Raspberry Pi 2 and 3. This `BUS_TO_PHYS` macro was first seen in https://github.com/raspberrypi/userland/commit/3b81b91c18ff19f97033e146a9f3262ca631f0e9 .

Please merge these changes to your repo. Thanks.
