### PR TITLE
Fixes framework search paths in examples

### DIFF
--- a/examples/SavedModelExample/SavedModelExample.xcodeproj/project.pbxproj
+++ b/examples/SavedModelExample/SavedModelExample.xcodeproj/project.pbxproj
@@ -246,10 +246,10 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
+					../../iOSLibrary,
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"\"$(SRCROOT)/../../\"",
-					/Users/petewarden/vagrant/DeepBeliefSDK/iOSLibrary,
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -301,10 +301,10 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
+					../../iOSLibrary,
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"\"$(SRCROOT)/../../\"",
-					/Users/petewarden/vagrant/DeepBeliefSDK/iOSLibrary,
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;


### PR DESCRIPTION
Looks like a hard path was left over in one of the examples. Caused the same issue for me that #24 and #54 ran into. PR corrects path.